### PR TITLE
Fix "Error 13" wrong file size and "is a directory" error when installing board in Arduino IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # arduino-board-index
+To install the MisfitTech boards for the Arduino IDE follow these [instructions](https://misfittech.net/blog/arduino-package-install/).
+The Board Manager URL should point to the `package_misfittech_index.json` file in this repository.
+
+If there is an error installing the board, consider looking at the following links:
+* [Cannot find misfitTech SAMD Boards in Arduino board manager](https://groups.google.com/g/smart-stepper/c/Dt03-1skbYc)
+* [Smart Stepper Google Group](https://groups.google.com/g/smart-stepper)

--- a/package_misfittech_index.json
+++ b/package_misfittech_index.json
@@ -15,7 +15,7 @@
           "help": {
             "online": "http://misfittech.net"
           },
-          "version": "1.0.0",
+          "version": "1.0.1",
           "architecture": "samd",
           "archiveFileName": "misfittech_samd-1.0.1.tar.bz2",
           "boards": [

--- a/package_misfittech_index.json
+++ b/package_misfittech_index.json
@@ -10,14 +10,14 @@
             {
           "category": "MisfitTech",
           "name": "MisfitTech SAMD Boards",
-          "url": "https://github.com/Misfittech/arduino-board-index/raw/master/boards/misfittech_samd-1.0.0.tar.bz2",
-          "checksum": "SHA-256:56A29C6B51540AA032FB18977258F7CE110D30C45A22F9ACFD8F81F744EB9041",
+          "url": "https://github.com/jaredgonzales/arduino-board-index/raw/bugfix/extracting_directory_error/boards/misfit_samd-1.0.1.tar.bz2",
+          "checksum": "SHA-256:1e8086e8d59148e61063fa759424aa2c39cb0a6f73e288aa4c58c1f6ad3340ec",
           "help": {
             "online": "http://misfittech.net"
           },
           "version": "1.0.0",
           "architecture": "samd",
-          "archiveFileName": "misfittech_samd-1.0.0.tar.bz2",
+          "archiveFileName": "misfittech_samd-1.0.1.tar.bz2",
           "boards": [
             {
               "name": "Nano Zero"
@@ -45,7 +45,7 @@
               "name": "CMSIS"
             }
           ],
-          "size": "12852574"
+          "size": "10301440"
         }
       ],
       "tools": [],

--- a/package_misfittech_index.json
+++ b/package_misfittech_index.json
@@ -10,7 +10,7 @@
             {
           "category": "MisfitTech",
           "name": "MisfitTech SAMD Boards",
-          "url": "https://github.com/jaredgonzales/arduino-board-index/raw/bugfix/extracting_directory_error/boards/misfit_samd-1.0.1.tar.bz2",
+          "url": "https://github.com/jaredgonzales/arduino-board-index/raw/bugfix/extracting_directory_error/boards/misfittech_samd-1.0.1.tar.bz2",
           "checksum": "SHA-256:1e8086e8d59148e61063fa759424aa2c39cb0a6f73e288aa4c58c1f6ad3340ec",
           "help": {
             "online": "http://misfittech.net"


### PR DESCRIPTION
Updating the index file resolves #1. But I was still getting an error when trying to install the board through the Arduino IDE:
`Error: 13 INTERNAL: Cannot install platform: installing platform misfittech:samd@1.0.0: extracting archive: open /Users/jared/Library/Arduino15/tmp/package-4103374767: is a directory`

To fix this issue, I recompressed the file and updated the index with the new hash and size as shown in this pull request. A descriptive `README.md` was also added to aid any further troubleshooting. The links will need to be updated if merged or forked.